### PR TITLE
Security fixes in ETL script dependencies

### DIFF
--- a/scripts/data_manipulation/package-lock.json
+++ b/scripts/data_manipulation/package-lock.json
@@ -51,9 +51,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -61,9 +61,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "csvtojson": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.8.tgz",
-      "integrity": "sha512-DC6YFtsJiA7t/Yz+KjzT6GXuKtU/5gRbbl7HJqvDVVir+dxdw2/1EgwfgJdnsvUT7lOnON5DvGftKuYWX1nMOQ==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
+      "integrity": "sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==",
       "requires": {
         "bluebird": "^3.5.1",
         "lodash": "^4.17.3",

--- a/scripts/data_manipulation/package-lock.json
+++ b/scripts/data_manipulation/package-lock.json
@@ -194,9 +194,9 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "map-stream": {
       "version": "0.0.7",

--- a/scripts/data_manipulation/package.json
+++ b/scripts/data_manipulation/package.json
@@ -14,6 +14,6 @@
     "event-stream": "^4.0.1",
     "fast-csv": "^2.5.0",
     "json-concat": "0.0.1",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.15"
   }
 }

--- a/scripts/data_manipulation/package.json
+++ b/scripts/data_manipulation/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "big-json": "^2.0.2",
-    "csvtojson": "^2.0.8",
+    "csvtojson": "^2.0.10",
     "event-stream": "^4.0.1",
     "fast-csv": "^2.5.0",
     "json-concat": "0.0.1",


### PR DESCRIPTION
This pull request fixes the vulnerabilities reported by Github and npm, especially the lodash library and its dependencies.
For this purpose the command 'npm audit fix' was used, which required a subsequent 'npm update' to ensure the integrity of the dependencies.