### PR TITLE
fixed the test suite

### DIFF
--- a/app/src/app/shared/components/slider/slide/slide.component.ts
+++ b/app/src/app/shared/components/slider/slide/slide.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter, AfterViewInit, ElementRef } from '@angular/core';
 import { Entity } from 'src/app/shared/models/models';
 import { DataService } from 'src/app/core/services/data.service';
-import { Slide } from '../slider.component';
+import { Slide, makeDefaultSlide } from '../slider.component';
 
 /**
  * a slide of the slider.
@@ -15,7 +15,7 @@ import { Slide } from '../slider.component';
 })
 export class SlideComponent implements AfterViewInit {
   /** the slide that should be displayed */
-  @Input() slide: Slide;
+  @Input() slide: Slide = makeDefaultSlide();
 
   /** emits hovered artwork on item hover event */
   @Output()

--- a/app/src/app/shared/components/slider/slider.component.ts
+++ b/app/src/app/shared/components/slider/slider.component.ts
@@ -18,6 +18,24 @@ export interface Slide {
   id: number;
 }
 
+/**
+ * In order to test the Slide component individually
+ * we need a default slide that can be passed to it
+ * 
+ * @returns {Slide} a default slide
+ */
+export function makeDefaultSlide(id:number = 0, items:Array<Entity> = []): Slide {
+  return {
+    id,
+    items,
+    isFirstSlide: false,
+    isLastSlide: false,
+    nextSlide: null,
+    prevSlide: null,
+    loadContent: null
+  };
+}
+
 @Component({
   selector: 'app-slider',
   templateUrl: './slider.component.html',
@@ -56,15 +74,7 @@ export class SliderComponent implements OnChanges {
       // get next 8 items out of items array
       const items: Entity[] = this.items.slice(i * 8, i * 8 + 8);
 
-      const slide: Slide = {
-        items,
-        prevSlide: null,
-        nextSlide: null,
-        loadContent: false,
-        isFirstSlide: false,
-        isLastSlide: false,
-        id: i,
-      };
+      const slide: Slide = makeDefaultSlide(i, items);
 
       if (i === numberOfSlides - 1) {
         slide.isLastSlide = true;


### PR DESCRIPTION
19 / 20 tests were passing, the last one failed, because the Slide component was not testable separately from the Slider component.

Adding a `makeDefaultSlide` function and using it as the default Input of a Slide fixed the test, and also made the Slider component code a little more readable in my opinion.

One day we could replace this with a Builder or Factory for Slides, but this should do for now.

Feedback welcome 😉 