### PR TITLE
ETL video id check bug fix and enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ apicache-py3
 *.ctrl
 *.lwp
 /.idea/
+/scripts/data_manipulation/google_dev_key.txt

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 crawler_output
 *.pyc
+/data_manipulation/google_dev_key.txt

--- a/scripts/data_manipulation/script_add_youtube_videos.py
+++ b/scripts/data_manipulation/script_add_youtube_videos.py
@@ -5,7 +5,10 @@ import sys
 import requests
 
 ADD_FOR_TYPES = ["artwork", "artist", "movement"]
-GOOGLE_DEV_KEY = open("google_dev_key.txt").read()
+try:
+    GOOGLE_DEV_KEY = open("google_dev_keyy.txt").read()
+except FileNotFoundError:
+    GOOGLE_DEV_KEY = ""
 
 
 def check_yt_id_valid(id) -> bool:
@@ -33,6 +36,9 @@ def add_youtube_videos(
         check_ids=True
 ) -> None:
     """Load the video csv file and add the links to the ontology file"""
+    if GOOGLE_DEV_KEY == "":
+        check_ids = False
+
     videos = {}
     broken_ids = []
 

--- a/scripts/data_manipulation/script_add_youtube_videos.py
+++ b/scripts/data_manipulation/script_add_youtube_videos.py
@@ -6,7 +6,7 @@ import requests
 
 ADD_FOR_TYPES = ["artwork", "artist", "movement"]
 try:
-    GOOGLE_DEV_KEY = open("google_dev_keyy.txt").read()
+    GOOGLE_DEV_KEY = open("google_dev_key.txt").read()
 except FileNotFoundError:
     GOOGLE_DEV_KEY = ""
 

--- a/scripts/data_manipulation/script_add_youtube_videos.py
+++ b/scripts/data_manipulation/script_add_youtube_videos.py
@@ -76,5 +76,5 @@ def add_youtube_videos(
 
 
 if __name__ == "__main__":
-    check = len(sys.argv) > 1 and sys.argv[1] == "-c"
+    check = "-c" in sys.argv
     add_youtube_videos(check_ids=check)

--- a/scripts/data_manipulation/script_add_youtube_videos.py
+++ b/scripts/data_manipulation/script_add_youtube_videos.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import sys
 
 import requests
 
@@ -19,7 +20,7 @@ def check_yt_id_valid(id) -> bool:
         return video_exists or res.status_code == 403
         # 403 means api usage limit is reached
 
-    except requests.HTTPError or KeyError:
+    except (requests.HTTPError, KeyError):
         # Unexpected request errors
         # Key error if API response is broken
         return True
@@ -28,25 +29,30 @@ def add_youtube_videos(
         videofile_location="youtube_videos.csv",
         ontology_location="../crawler_output/art_ontology.json",
         ontology_output_location="../crawler_output/art_ontology.json",
-        check_links=True
+        broken_ids_logging_location="../crawler_output/broken_links.json",
+        check_ids=True
 ) -> None:
     """Load the video csv file and add the links to the ontology file"""
     videos = {}
+    broken_ids = []
 
     with open(videofile_location, encoding="utf-8") as csv_file:
         csv_reader = csv.DictReader(csv_file, delimiter=';')
         for row in csv_reader:
             qid = row["q_id"]
             yt_id = row["yt_id"]
-            if check_links and not check_yt_id_valid(yt_id):
-                print("Found broken id: {} ({})".format(yt_id, row["videoname"]))
+            if check_ids and not check_yt_id_valid(yt_id):
+                broken_ids.append(row)
                 continue
             if qid not in videos:
                 videos[qid] = []
             video_url = "https://www.youtube.com/embed/{}".format(yt_id)
             videos[qid].append(video_url)
 
-    print("done")
+    if len(broken_ids) > 0:
+        broken_ids_out = json.dumps(broken_ids)
+        with open(broken_ids_logging_location, 'w') as json_file:
+            json_file.write(broken_ids_out)
 
     with open(ontology_location, encoding="utf-8") as json_file:
         ontology = json.load(json_file)
@@ -64,4 +70,5 @@ def add_youtube_videos(
 
 
 if __name__ == "__main__":
-    add_youtube_videos()
+    check = len(sys.argv) > 1 and sys.argv[1] == "-c"
+    add_youtube_videos(check_ids=check)

--- a/scripts/run_etl.sh
+++ b/scripts/run_etl.sh
@@ -14,4 +14,4 @@ node ../data_manipulation/script_motifs_rank.js
 node ../data_manipulation/script_flatten_rank.js
 
 cd ../data_manipulation
-python3 .\script_add_youtube_videos.py -c
+python3 .\script_add_youtube_videos.py

--- a/scripts/run_etl.sh
+++ b/scripts/run_etl.sh
@@ -14,4 +14,4 @@ node ../data_manipulation/script_motifs_rank.js
 node ../data_manipulation/script_flatten_rank.js
 
 cd ../data_manipulation
-python3 .\script_add_youtube_videos.py
+python3 .\script_add_youtube_videos.py -c


### PR DESCRIPTION
I fixed the bug. Broken IDs are now logged to a file in crawler_output. 

The check can now be triggered by the -c option (see run_etl.sh)