### PR TITLE
Fixed build error

### DIFF
--- a/app/src/app/pages/search-result/search-result.routing.module.ts
+++ b/app/src/app/pages/search-result/search-result.routing.module.ts
@@ -14,7 +14,7 @@ const searchResultRoutes: Routes = [
 
 @NgModule({
   declarations: [SearchResultComponent],
-  imports: [CommonModule, SharedModule, RouterModule.forChild(searchResultRoutes), NgbModule.forRoot()],
+  imports: [CommonModule, SharedModule, RouterModule.forChild(searchResultRoutes), NgbModule],
   exports: [SearchResultComponent],
 })
 export class SearchResultRoutingModule {}


### PR DESCRIPTION
ERROR in app/pages/search-result/search-result.routing.module.ts:17:94 - error TS2339: Property 'forRoot' does not exist on type 'typeof NgbModule'.

17   imports: [CommonModule, SharedModule, RouterModule.forChild(searchResultRoutes), NgbModule.forRoot()],

                                                                                                ~~~~~~~

ERROR in Error during template compile of 'SearchResultRoutingModule'

  Function calls are not supported in decorators but 'NgbModule' was called.