### PR TITLE
reverting to the working service implementation

### DIFF
--- a/app/src/app/core/services/elasticsearch/data.service.ts
+++ b/app/src/app/core/services/elasticsearch/data.service.ts
@@ -135,10 +135,12 @@ export class DataService {
      * @param iconclasses an Array of Iconclasses to retrieve
      * @returns an Array containing the iconclassData to the respective Iconclass
      */
-    public async getIconclassData(iconclasses:Array<Iconclass>): Promise<any> {
-        return await Promise.all(iconclasses.map(async (key:Iconclass) =>
-            await this.http.get(`http://iconclass.org/${key}.json`)
+    public async getIconclassData(iconclasses: Array<Iconclass>): Promise<any> {
+        const results: Array<any> = [];
+        await Promise.all(iconclasses.map(async (key: Iconclass) =>
+            results.push(await this.http.get(`http://iconclass.org/${key}.json`).toPromise())
         ));
+        return results;
     }
 
     /**


### PR DESCRIPTION
The refactoring of the service method broke the iconography feature.

![image](https://user-images.githubusercontent.com/22763390/70704046-8dbdf300-1cd1-11ea-9997-3cd849bead98.png)

This is a revert to the working implementation.