### PR TITLE
Video refresh bug fix

### DIFF
--- a/app/src/app/shared/components/video/video.component.ts
+++ b/app/src/app/shared/components/video/video.component.ts
@@ -39,6 +39,8 @@ export class VideoComponent implements OnInit, OnDestroy, AfterViewInit, OnChang
         this.validateVideoExists(videoUrl)
           .then(exists => this.videoExists = exists);
       }
+    } else {
+      this.videoExists = false;
     }
   }
 


### PR DESCRIPTION
The previous pull request only fixed changes from pages that have videos both. The video was still displayed if the new page had no video assigned to it.