### PR TITLE
Fix/elasticsearch index swap

### DIFF
--- a/scripts/upload_to_elasticsearch/elasticsearch_helper.py
+++ b/scripts/upload_to_elasticsearch/elasticsearch_helper.py
@@ -172,7 +172,8 @@ def create_snapshot_for_index(
                                - Following entry in elasticsearch.yml required:
                                path.repo: ["path_to_folder"]
     """
-    es = Elasticsearch()
+    # Increase timeout because creating snapshots had exceeded the default timeout of 10 seconds
+    es = Elasticsearch(timeout=30) 
 
     try:
         # Check if repository already was created

--- a/scripts/upload_to_elasticsearch/elasticsearch_helper.py
+++ b/scripts/upload_to_elasticsearch/elasticsearch_helper.py
@@ -133,8 +133,6 @@ def swap_index(index_name_new, index_name_current, index_name_old) -> bool:
         snapshot_name=index_current_snapshot, 
         index_name=index_name_current,
         new_index_name=index_name_old)
-    # Close old index because we don't need it right now
-    es.indices.close(index_name_old)
 
     # Second swap
     # Apply index_new_snapshot on index_current


### PR DESCRIPTION
The closing part is a bit weird but i can't check it locally because i haven't had the problem there. The languagekey_old indices can only be accessed from within the server so it doesn't make a difference whether they are open or closed for us. I don't know if it affects performance but as long as there are no problems i wouldn't invest time in it.