### PR TITLE
Fix bug where videoExists was not reset when a new artwork was loaded.

### DIFF
--- a/app/src/app/pages/artist/artist.component.ts
+++ b/app/src/app/pages/artist/artist.component.ts
@@ -33,6 +33,9 @@ export class ArtistComponent implements OnInit, OnDestroy {
 
   /** hook that is executed at component initialization */
   ngOnInit() {
+    this.route.params.subscribe(() => {
+      this.videoExists = false;
+    });
     /** Extract the id of entity from URL params. */
     this.route.paramMap.pipe(takeUntil(this.ngUnsubscribe)).subscribe(async (params) => {
       const artistId = params.get('artistId');
@@ -40,7 +43,7 @@ export class ArtistComponent implements OnInit, OnDestroy {
       this.artist = await this.dataService.findById<Artist>(artistId, EntityType.ARTIST);
 
       /** load slider items */
-      this.dataService.findArtworksByType("artists", [this.artist.id])
+      this.dataService.findArtworksByType('artists', [this.artist.id])
         .then(artworks => this.sliderItems = shuffle(artworks));
       /** dereference movements  */
       this.dataService.findMultipleById(this.artist.movements as any, EntityType.MOVEMENT)
@@ -63,7 +66,7 @@ export class ArtistComponent implements OnInit, OnDestroy {
    */
   private aggregatePictureMovementsToArtist() {
     const allMovements: Partial<Movement>[] = [];
-    this.dataService.findArtworksByType("artists", [this.artist.id]).then((artworks) => {
+    this.dataService.findArtworksByType('artists', [this.artist.id]).then((artworks) => {
       artworks.forEach(artwork => {
         artwork.movements.forEach(movement => {
           if (movement !== '') {
@@ -80,8 +83,7 @@ export class ArtistComponent implements OnInit, OnDestroy {
     });
   }
 
-  /**
-   /** calculates the size of meta data item section
+  /** calculates the size of meta data item section
    * every attribute: +3
    * if attribute is array and size > 3 -> + arraylength
    */

--- a/app/src/app/pages/artwork/artwork.component.ts
+++ b/app/src/app/pages/artwork/artwork.component.ts
@@ -1,11 +1,11 @@
-import { Component, OnInit, OnDestroy, HostListener, Inject, LOCALE_ID } from '@angular/core';
-import { Artwork, EntityType, Iconclass, EntityIcon } from 'src/app/shared/models/models';
-import { takeUntil } from 'rxjs/operators';
-import { ActivatedRoute } from '@angular/router';
-import { Subject } from 'rxjs';
+import {Component, OnInit, OnDestroy, HostListener} from '@angular/core';
+import {Artwork, EntityType, EntityIcon} from 'src/app/shared/models/models';
+import {takeUntil} from 'rxjs/operators';
+import {ActivatedRoute} from '@angular/router';
+import {Subject} from 'rxjs';
 import * as _ from 'lodash';
-import { DataService } from 'src/app/core/services/elasticsearch/data.service';
-import { shuffle } from 'src/app/core/services/utils.service';
+import {DataService} from 'src/app/core/services/elasticsearch/data.service';
+import {shuffle} from 'src/app/core/services/utils.service';
 
 /** interface for the tabs */
 interface ArtworkTab {
@@ -19,6 +19,7 @@ interface ArtworkTab {
   selector: 'app-artwork',
   templateUrl: './artwork.component.html',
   styleUrls: ['./artwork.component.scss'],
+  host: {'window:beforeunload': 'doSomething'},
 })
 export class ArtworkComponent implements OnInit, OnDestroy {
   /**
@@ -74,6 +75,10 @@ export class ArtworkComponent implements OnInit, OnDestroy {
    * @description hook that is executed at component initialization
    */
   ngOnInit() {
+    this.route.params.subscribe(() => {
+      this.videoExists = false;
+    });
+
     // define tabs if not set
     if (!this.artworkTabs || !this.artworkTabs.length) {
       this.addTab(EntityType.ALL, true);
@@ -221,11 +226,10 @@ export class ArtworkComponent implements OnInit, OnDestroy {
   /**
    * Add tab to artwork tab array
    * @param type Tab title
-   * @param icon Tab icon
    * @param active Is active tab
    */
   private addTab(type: EntityType, active: boolean = false) {
-    this.artworkTabs.push({ active, icon: EntityIcon[type.toUpperCase()], type, items: [] });
+    this.artworkTabs.push({active, icon: EntityIcon[type.toUpperCase()], type, items: []});
   }
 
   videoFound(event) {

--- a/app/src/app/pages/movement/movement.component.ts
+++ b/app/src/app/pages/movement/movement.component.ts
@@ -4,7 +4,7 @@ import {ActivatedRoute} from '@angular/router';
 import {takeUntil} from 'rxjs/operators';
 import {Movement, Artwork, EntityType} from 'src/app/shared/models/models';
 import {Subject} from 'rxjs';
-import * as _ from "lodash";
+import * as _ from 'lodash';
 import {shuffle} from 'src/app/core/services/utils.service';
 
 @Component({
@@ -25,7 +25,7 @@ export class MovementComponent implements OnInit, OnDestroy {
   /** Change collapse icon; true if more infos are folded in */
   collapse = true;
 
-  /** Toggle bool for displaying either timeline or artworks carousel component **/
+  /** Toggle bool for displaying either timeline or artworks carousel component */
   showTimelineNotArtworks = true;
 
   /** a video was found */
@@ -36,6 +36,9 @@ export class MovementComponent implements OnInit, OnDestroy {
 
   /** hook that is executed at component initialization */
   ngOnInit() {
+    this.route.params.subscribe(() => {
+      this.videoExists = false;
+    });
     /** Extract the id of entity from URL params. */
     this.route.paramMap.pipe(takeUntil(this.ngUnsubscribe)).subscribe(async (params) => {
       const movementId = params.get('movementId');
@@ -44,7 +47,7 @@ export class MovementComponent implements OnInit, OnDestroy {
       this.movement = await this.dataService.findById<Movement>(movementId, EntityType.MOVEMENT);
 
       /** load slider items */
-      await this.dataService.findArtworksByType("movements", [this.movement.id])
+      await this.dataService.findArtworksByType('movements', [this.movement.id])
         .then(artworks => this.sliderItems = shuffle(artworks));
 
       /** dereference influenced_bys  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,11 @@
 {
-  "lockfileVersion": 1
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "std": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/std/-/std-0.1.40.tgz",
+      "integrity": "sha1-Nnil9lCU2eG2teJu2/wCErg0K3E="
+    }
+  }
 }


### PR DESCRIPTION
Fix bug where videoExists was not reset when a new artwork was loaded. This happens when the page but not the component changes. Fix detects changes to URL parameters and resets videoExists accordingly. Changed for Artist and Movement too, even this bug won't occur on these yet, because there are no links between two artists/movements (yet).