### PR TITLE
Reducing Response Size

### DIFF
--- a/app/src/app/core/services/elasticsearch/data.service.ts
+++ b/app/src/app/core/services/elasticsearch/data.service.ts
@@ -114,7 +114,7 @@ export class DataService {
             .shouldMatch("label", `${label}`)
             .shouldWildcard("label", `${label}`)
             .sort()
-            .size(2000);
+            .size(200);
         return this.performQuery(query);
     }
 


### PR DESCRIPTION
After the talk about the mid-tier mobile search in Issue 156, we agreed on the reduction of the response size, if there is no alternative like subqueries in Elasticsearch. After research me and @marvinseith  found out there is no possible way to achieve subqueries without multiple requests in Elasticsearch. Therefore we chose the fast solution.