### PR TITLE
Percent encoding only in rdf generation

### DIFF
--- a/etl/data_extraction/get_wikidata_items.py
+++ b/etl/data_extraction/get_wikidata_items.py
@@ -32,7 +32,6 @@ import sys
 import time
 from pathlib import Path
 from urllib.error import HTTPError
-import urllib
 from typing import List, Dict, Set, Iterator, Optional
 
 from data_extraction import map_wd_attribute
@@ -177,9 +176,6 @@ def get_image_url_by_name(image_name: str) -> str:
     """
     image_name = image_name.replace(" ", "_")
     hash = hashlib.md5(image_name.encode("utf-8")).hexdigest()
-    image_name = urllib.parse.quote(
-        image_name
-    )  # apply quote encoding always after hash calculation
     hash_index_1 = hash[0]
     hash_index_1_and_2 = hash[0] + hash[1]
     url = "https://upload.wikimedia.org/wikipedia/commons/{0}/{1}/{2}".format(

--- a/etl/data_extraction/map_wd_attribute.py
+++ b/etl/data_extraction/map_wd_attribute.py
@@ -2,7 +2,6 @@
 """
 import inspect
 import re
-import urllib
 from pathlib import Path
 from typing import Any, Callable, Dict, List
 
@@ -104,10 +103,7 @@ def try_get_wikipedia_link(entity_dict: Dict, langkey: str, oab_type: str) -> st
         Wikipedia URL from wikidata response
     """
     return "https://{0}.wikipedia.org/wiki/{1}".format(
-        langkey,
-        urllib.parse.quote(
-            entity_dict[SITELINKS][f"{langkey}wiki"]["title"].replace(" ", "_")
-        ),
+        langkey, entity_dict[SITELINKS][f"{langkey}wiki"]["title"].replace(" ", "_"),
     )
 
 

--- a/etl/generate_rdf/generate_rdf.py
+++ b/etl/generate_rdf/generate_rdf.py
@@ -8,7 +8,24 @@ Raises:
 """
 import datetime
 import json
+import urllib
 from pathlib import Path
+
+
+def uri_validator(uri: str) -> bool:
+    """Validates if a string is an URI
+
+    Args:
+        uri: String of an possible URI
+
+    Returns:
+        True if the string is an URI, else False
+    """
+    try:
+        result = urllib.parse.urlparse(uri)
+        return all([result.scheme, result.netloc, result.path])
+    except:
+        return False
 
 
 def generate_rdf(
@@ -158,6 +175,9 @@ def generate_rdf(
                                             output.write(" , ")
                                 else:
                                     value = str(value)
+                                    if uri_validator(value):
+                                        result = urllib.parse.urlparse(value)
+                                        value = f"{result.scheme}://{result.netloc}{urllib.parse.quote(result.path)}"
                                     if value != "":  # cell not empty
                                         if t == "string" and '"' in value:
                                             value = value.replace(


### PR DESCRIPTION
The wikipedia api seems to have problems resolving some pages when the title string is percent encoded so older changes were reverted and the percent encoding was only applied for the rdf generation.