### PR TITLE
Avoid redirects for wikidata entities

### DIFF
--- a/etl/data_extraction/get_wikidata_items.py
+++ b/etl/data_extraction/get_wikidata_items.py
@@ -144,6 +144,7 @@ def wikidata_entity_request(
         "languages": "|".join(language_keys),
         "sitefilter": "|".join(langkeyPlusWikiList),
         "props": "|".join(props),
+        "redirects": "no",
         # if the server needs more than maxlag seconds to process
         # the query an error response is returned
         "maxlag": maxlag,

--- a/etl/data_extraction/get_wikipedia_extracts.py
+++ b/etl/data_extraction/get_wikipedia_extracts.py
@@ -40,6 +40,7 @@ def get_wikipedia_page_ids(
 ) -> Dict:
     """Function to get the wikipedia page ids from their label referenced in the sitelinks
 
+    https://en.wikipedia.org/w/api.php?action=help&modules=query
     sitelink de: Mona_Lisa is resolved to
 
     Args:
@@ -115,6 +116,8 @@ def get_wikipedia_extracts(
     maxlag: Optional[int] = MAX_LAG,
 ):
     """Get the wikipedia extracts (in our data model they're called abstracts)
+
+    https://en.wikipedia.org/w/api.php?action=help&modules=query
 
     Args:
         items: List of entities


### PR DESCRIPTION
For the wikipedia query API this seems
not to be possible, but in this script
redirects are skipped anyway

fixes #343 and #332 