### PR TITLE
Hotfix iconclass

### DIFF
--- a/app/src/app/core/services/elasticsearch/data.service.ts
+++ b/app/src/app/core/services/elasticsearch/data.service.ts
@@ -202,12 +202,12 @@ export class DataService {
   /**
    * Retrieves IconclassData from the iconclass.org web-service
    * @see http://www.iconclass.org/help/lod for the documentation
-   * @param iconclass an Array of Iconclasses to retrieve
+   * @param iconclasses an Array of Iconclasses to retrieve
    * @returns an Array containing the iconclassData to the respective Iconclass
    */
-  public async getIconclassData(iconclass: Array<Iconclass>): Promise<any> {
+  public async getIconclassData(iconclasses: Array<Iconclass>): Promise<any> {
     const iconclassData = await Promise.all(
-      iconclass.map(async (key: Iconclass) => {
+      iconclasses.map(async (key: Iconclass) => {
         try {
           return await this.http.get(`https://openartbrowser.org/api/iconclass/${key}.json`).toPromise();
         } catch (error) {

--- a/app/src/app/core/services/elasticsearch/data.service.ts
+++ b/app/src/app/core/services/elasticsearch/data.service.ts
@@ -202,13 +202,21 @@ export class DataService {
   /**
    * Retrieves IconclassData from the iconclass.org web-service
    * @see http://www.iconclass.org/help/lod for the documentation
-   * @param iconclasses an Array of Iconclasses to retrieve
+   * @param iconclass an Array of Iconclasses to retrieve
    * @returns an Array containing the iconclassData to the respective Iconclass
    */
-  public async getIconclassData(iconclasses: Array<Iconclass>): Promise<any> {
-    return await Promise.all(
-      iconclasses.map(async (key: Iconclass) => await this.http.get(`https://openartbrowser.org/api/iconclass/${key}.json`).toPromise())
+  public async getIconclassData(iconclass: Array<Iconclass>): Promise<any> {
+    const iconclassData = await Promise.all(
+      iconclass.map(async (key: Iconclass) => {
+        try {
+          return await this.http.get(`https://openartbrowser.org/api/iconclass/${key}.json`).toPromise();
+        } catch (error) {
+          console.warn(error);
+          return null;
+        }
+      })
     );
+    return iconclassData.filter(entry => entry !== null);
   }
 
   /**


### PR DESCRIPTION
The bug in #430 occured because the api returned `null` instead of a valid iconclass object - since the guard in the component.html expects valid iconclasses when the array has elements it tried to access properties on `[null]`.

We fixed this on the dataService level and also added a try-catch for cases in which only one of multiple iconclasses can not be found.