### PR TITLE
Feature 410 significant events

### DIFF
--- a/app/src/app/pages/artwork/artwork.component.ts
+++ b/app/src/app/pages/artwork/artwork.component.ts
@@ -112,7 +112,7 @@ export class ArtworkComponent implements OnInit, OnDestroy {
       if (this.artwork.videos && this.artwork.videos.length > 0) {
         this.uniqueVideos.unshift(this.artwork.videos[0]);
       }
-      
+
       if (this.artwork) {
         this.mergeMotifs();
         this.combineEventData();
@@ -272,14 +272,36 @@ export class ArtworkComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * combines the "new" attributes 
-   * (exhibition history and later significant event)
-   * for a unified display mode 
+   * combines the "new" attributes and sorts them by start year
+   * (exhibition history and significant event)
+   * for a unified display mode
    */
-  combineEventData () {
-    this.artwork.events = [
-      ...this.artwork['exhibition_history']
-      /* ...this.artwork['significant_events'] */
-    ];
+  combineEventData() {
+    this.artwork.events = [];
+    for (let i = 0; i < this.artwork['exhibition_history'].length; i++) {
+      const exhibitionHistory = this.artwork['exhibition_history'][i];
+      this.artwork.events.push({start: exhibitionHistory.start_time,
+        end: exhibitionHistory.end_time,
+        label: exhibitionHistory.label,
+        description: exhibitionHistory.description,
+        type: exhibitionHistory.type});
+    }
+
+    for (let i = 0; i < this.artwork['significant_event'].length; i++) {
+      const significantEvents = this.artwork['significant_event'][i]
+      this.artwork.events.push({start: significantEvents.point_in_time,
+        end: significantEvents.end_time,
+        label: significantEvents.label,
+        type: significantEvents.type});
+    }
+
+    this.artwork.events.sort(((a, b) => {
+      if (a.start < b.start) {
+        return -1;
+      } else if (a.start > b.start) {
+        return 1;
+      }
+      return 0;
+    }));
   }
 }

--- a/app/src/app/pages/artwork/artwork.component.ts
+++ b/app/src/app/pages/artwork/artwork.component.ts
@@ -277,31 +277,15 @@ export class ArtworkComponent implements OnInit, OnDestroy {
    * for a unified display mode
    */
   combineEventData() {
-    this.artwork.events = [];
-    for (let i = 0; i < this.artwork['exhibition_history'].length; i++) {
-      const exhibitionHistory = this.artwork['exhibition_history'][i];
-      this.artwork.events.push({start: exhibitionHistory.start_time,
-        end: exhibitionHistory.end_time,
-        label: exhibitionHistory.label,
-        description: exhibitionHistory.description,
-        type: exhibitionHistory.type});
-    }
-
-    for (let i = 0; i < this.artwork['significant_event'].length; i++) {
-      const significantEvents = this.artwork['significant_event'][i]
-      this.artwork.events.push({start: significantEvents.point_in_time,
-        end: significantEvents.end_time,
-        label: significantEvents.label,
-        type: significantEvents.type});
-    }
-
-    this.artwork.events.sort(((a, b) => {
-      if (a.start < b.start) {
-        return -1;
-      } else if (a.start > b.start) {
-        return 1;
+    this.artwork.events = [
+      ...this.artwork['exhibition_history'],
+      ...this.artwork['significant_event']
+    ].map(event => {
+      if (event.type === 'significant_event') {
+        event.start_time = event['point_in_time'];
+        delete event['point_in_time'];
       }
-      return 0;
-    }));
+      return event;
+    }).sort((left, right) => left.start_time - right.start_time);
   }
 }

--- a/app/src/app/shared/components/event-table/event-table.component.css
+++ b/app/src/app/shared/components/event-table/event-table.component.css
@@ -1,8 +1,5 @@
 .event-entry {
   margin-bottom: 5px;
-  list-style-type: disc;
-  list-style-position: inside;
-  display: list-item;
 }
 
 .time-label {
@@ -17,7 +14,6 @@
 
 .event-description {
   margin-left: 10%;
-  padding-left: 20px;
   font-style: italic;
 }
 

--- a/app/src/app/shared/components/event-table/event-table.component.css.map
+++ b/app/src/app/shared/components/event-table/event-table.component.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["event-table.component.scss"],"names":[],"mappings":"AAAA;EACE;EACA;EACA;EACA;;;AAGF;EACE;EACA;;;AAGF;EACE;EACA;;;AAGF;EACE;EACA;EACA","file":"event-table.component.css"}
+{"version":3,"sourceRoot":"","sources":["event-table.component.scss"],"names":[],"mappings":"AAAA;EACE;;;AAGF;EACE;EACA;;;AAGF;EACE;EACA;;;AAGF;EACE;EACA","file":"event-table.component.css"}

--- a/app/src/app/shared/components/event-table/event-table.component.ts
+++ b/app/src/app/shared/components/event-table/event-table.component.ts
@@ -20,14 +20,14 @@ export class EventTableComponent implements OnChanges {
   }
 
   isDisplayable(event) {
-    return typeof event.start === 'number' && event.label.length;
+    return typeof event.start_time === 'number' && event.label.length;
   }
 
   getTimeLabel(event) {
-    if (event.end && event.end !== event.start) {
-      return event.start + ' - ' + event.end;
+    if (event.end_time && event.end_time !== event.start_time) {
+      return event.start_time + ' - ' + event.end_time;
     }
-    return event.start;
+    return event.start_time;
   }
 
   getEventLabel(event) {

--- a/app/src/app/shared/components/event-table/event-table.component.ts
+++ b/app/src/app/shared/components/event-table/event-table.component.ts
@@ -20,14 +20,14 @@ export class EventTableComponent implements OnChanges {
   }
 
   isDisplayable(event) {
-    return typeof event.start_time === 'number' && event.label.length;
+    return typeof event.start === 'number' && event.label.length;
   }
 
   getTimeLabel(event) {
-    if (event.end_time && event.end_time !== event.start_time) {
-      return event.start_time + ' - ' + event.end_time;
+    if (event.end && event.end !== event.start) {
+      return event.start + ' - ' + event.end;
     }
-    return event.start_time;
+    return event.start;
   }
 
   getEventLabel(event) {

--- a/app/src/app/shared/models/artwork.interface.ts
+++ b/app/src/app/shared/models/artwork.interface.ts
@@ -28,8 +28,8 @@ export interface Artwork extends Entity {
 }
 
 export interface SignificantEvent {
-  start: number;
-  end?: number;
+  start_time: number;
+  end_time?: number;
   label: string;
   description?: string;
   type: string;

--- a/app/src/app/shared/models/artwork.interface.ts
+++ b/app/src/app/shared/models/artwork.interface.ts
@@ -32,4 +32,5 @@ export interface SignificantEvent {
   end?: number;
   label: string;
   description?: string;
+  type: string;
 }


### PR DESCRIPTION
Implemented display of significant events as detailed in #410 and first proposed in #292. 
Both significant events and the exhibition history are now displayed on the artwork page under the "Events" entry. The Events are sorted by their start year.
Significant events are displayed as their start and, if available, end year and their label.
The exhibition history is displayed as start and, if available, end year as well as their label and their description if they have one.

The events are merged and sorted in the artwork_component.ts.