### PR TITLE
Fix deployment build output

### DIFF
--- a/app/angular.json
+++ b/app/angular.json
@@ -187,7 +187,7 @@
                 }
               ],
               "aot": true,
-              "outputPath": "dist/browser/en",
+              "outputPath": "dist/browser",
               "i18nMissingTranslation": "error"
             },
             "fr-production": {
@@ -251,7 +251,7 @@
                 }
               ],
               "aot": true,
-              "outputPath": "dist/browser/de",
+              "outputPath": "dist/browser",
               "i18nMissingTranslation": "error"
             },
             "es-production": {

--- a/app/angular.json
+++ b/app/angular.json
@@ -46,6 +46,7 @@
             ],
             "aot": true,
             "outputPath": "dist/art-browser",
+            "deleteOutputPath": false,
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
@@ -186,7 +187,7 @@
                 }
               ],
               "aot": true,
-              "outputPath": "dist/browser",
+              "outputPath": "dist/browser/en",
               "i18nMissingTranslation": "error"
             },
             "fr-production": {
@@ -250,7 +251,7 @@
                 }
               ],
               "aot": true,
-              "outputPath": "dist/browser",
+              "outputPath": "dist/browser/de",
               "i18nMissingTranslation": "error"
             },
             "es-production": {


### PR DESCRIPTION
When building the app via `npm run build-locale` the `dist` directory was removed after each build. Therefor the only left build was the `it` build which resulted in a missing deployment of the other languages. I fixed it by setting the corresponding option in the angular.json file. I really do not know why this worked before (since this option is actually not that new) but it might be related to some angular updates.