### PR TITLE
462-timeline items not accessible

### DIFF
--- a/app/src/app/shared/components/timeline/timeline.component.ts
+++ b/app/src/app/shared/components/timeline/timeline.component.ts
@@ -126,7 +126,8 @@ export class TimelineComponent implements OnChanges {
       const endOfTimeline = this.items[this.items.length - 1].date -
         (this.items[this.items.length - 1].date % this.periodSpan) + this.periodSpan;
       // Set the slider of the timeline to the middle!
-      this.value = (beginOfTimeline + endOfTimeline) / 2;
+      // this.value = (beginOfTimeline + endOfTimeline) / 2;
+      this.value = this.items[Math.floor(this.items.length / 2)].date;
       this.previousValue = this.value;
       this.refreshComponent();
     }
@@ -209,8 +210,6 @@ export class TimelineComponent implements OnChanges {
     /** Set slider options */
     const newOptions: Options = Object.assign({}, this.options);
     newOptions.stepsArray = sliderSteps;
-    newOptions.minLimit = firstDate - firstPeriod;
-    newOptions.maxLimit = lastDate - firstPeriod;
     this.options = newOptions;
   }
 

--- a/app/src/app/shared/components/timeline/timeline.component.ts
+++ b/app/src/app/shared/components/timeline/timeline.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, HostListener} from '@angular/core';
+import {Component, Input, HostListener, OnChanges} from '@angular/core';
 import {Artist, Artwork, Entity, EntityType} from 'src/app/shared/models/models';
 import {CustomStepDefinition, Options} from '@angular-slider/ngx-slider';
 import {animate, state, style, transition, trigger} from '@angular/animations';
@@ -27,7 +27,7 @@ interface TimelineItem extends Entity {
     ])
   ]
 })
-export class TimelineComponent {
+export class TimelineComponent implements OnChanges {
   /** Artworks that should be displayed in this slider */
   @Input() artworks: Artwork[] = [];
   /** Decide whether artists should be displayed */
@@ -74,7 +74,7 @@ export class TimelineComponent {
     showTicks: true,
     showSelectionBar: false,
     stepsArray: [],
-    animateOnMove:true,
+    animateOnMove: true,
     getPointerColor() {
       return '#00bc8c';
     },
@@ -179,17 +179,28 @@ export class TimelineComponent {
       const distinctItems = this.items.filter(
         (thing, i, arr) => arr.findIndex(t => t.date === thing.date) === i
       );
+
+      /**
+       *  determine indices which divide distinctItems in averagePeriodCount blocks of roughly the same length
+       *  this method guarantees that the first and last element are always an index
+       */
+      const stepNr = (distinctItems.length - 1) / (this.averagePeriodCount - 1);
+      const indices = [];
+      for (let i = 0; i < this.averagePeriodCount; i++) {
+        indices.push(Math.floor(stepNr * i));
+      }
+
       sliderSteps = distinctItems.map((item, index) => {
         const step = {
           value: item.date,
           legend: ''
         };
-        if (index % Math.floor(distinctItems.length / this.averagePeriodCount) === 0) {
+
+        /** if current index is in indices make this item a legend point */
+        if (indices.includes(index)) {
           step.legend = item.date.toString();
         }
-        if (index === distinctItems.length - 1){
-          step.legend = item.date.toString();
-        }
+
         return step;
       });
     }

--- a/app/src/app/shared/components/timeline/timeline.component.ts
+++ b/app/src/app/shared/components/timeline/timeline.component.ts
@@ -176,12 +176,18 @@ export class TimelineComponent {
       }
     } else {
       /** if timeDifference bigger than maxSliderSteps, use the date values of the items */
-      sliderSteps = this.items.map((item, index) => {
+      const distinctItems = this.items.filter(
+        (thing, i, arr) => arr.findIndex(t => t.date === thing.date) === i
+      );
+      sliderSteps = distinctItems.map((item, index) => {
         const step = {
           value: item.date,
           legend: ''
         };
-        if (index % Math.floor(this.items.length / this.averagePeriodCount) === 0) {
+        if (index % Math.floor(distinctItems.length / this.averagePeriodCount) === 0) {
+          step.legend = item.date.toString();
+        }
+        if (index === distinctItems.length - 1){
           step.legend = item.date.toString();
         }
         return step;
@@ -205,7 +211,6 @@ export class TimelineComponent {
     const itemCountSmallerReference = 2;
     /** Amount of items where date is the exact slider value */
     const countReference = this.items.filter(item => +item.date === this.value).length;
-
     /** ReferenceIndex is the index of the first item with date equal to slider value or bigger */
     let referenceIndex: number;
     if (countReference > itemCountSmallerReference) {
@@ -214,7 +219,6 @@ export class TimelineComponent {
       const firstBiggerRef = this.items.findIndex(item => +item.date > this.value);
       referenceIndex = firstBiggerRef > 0 ? firstBiggerRef - 1 : this.items.length - (this.itemCountPerPeriod - 1);
     }
-
     /** Determine start index */
     if (0 >= referenceIndex - 1 && referenceIndex <= this.items.length - 3) {
       // first slide

--- a/app/src/app/shared/components/timeline/timeline.component.ts
+++ b/app/src/app/shared/components/timeline/timeline.component.ts
@@ -165,6 +165,9 @@ export class TimelineComponent implements OnChanges {
     const firstPeriod = firstDate - (firstDate % this.periodSpan);
     const lastPeriod = lastDate - (lastDate % this.periodSpan) + this.periodSpan;
 
+    /** setup options */
+    const newOptions: Options = Object.assign({}, this.options);
+
     /** Fill the slider steps with period legends respectively steps */
     const timeDifference = lastPeriod - firstPeriod;
     if (timeDifference <= this.maxSliderSteps) {
@@ -175,8 +178,16 @@ export class TimelineComponent implements OnChanges {
           sliderSteps.push({value: i});
         }
       }
+
+      /** set min and max slider limits */
+      newOptions.minLimit = firstDate - firstPeriod;
+      newOptions.maxLimit = lastDate - firstPeriod;
+
     } else {
-      /** if timeDifference bigger than maxSliderSteps, use the date values of the items */
+      /**
+       * if timeDifference bigger than maxSliderSteps, use distinct date values of the items
+       * This is done to avoid too much items in the timeline
+       */
       const distinctItems = this.items.filter(
         (thing, i, arr) => arr.findIndex(t => t.date === thing.date) === i
       );
@@ -206,9 +217,7 @@ export class TimelineComponent implements OnChanges {
       });
     }
 
-
     /** Set slider options */
-    const newOptions: Options = Object.assign({}, this.options);
     newOptions.stepsArray = sliderSteps;
     this.options = newOptions;
   }


### PR DESCRIPTION
#462. Fixes Bug #462 where the Timeline Items of Movement [Q1277524](https://openartbrowser.org/en/movement/Q1277524) were only partially accessible. This was caused by two problems in the timeline component:

1. When the timeline items were spanned across a large time difference (> ~ 900yrs) the initialisation did not initialize a timeline value for each year between the start year and the end year (standard behavior) but instead stepped through the item array to assign values based on the dates of the specific items in the timeline.
This was done in order to not exceed roughly 1000 items in the timeline (in case of the artist anonymous for example.)
The movement creating this bug however had several entries with the same date which resulted in duplicate values in the slider.
To combat this a filtered copy of the item list, without duplicates, is created which then gets used for the slider values init.
This solves duplicate values in the slider.

2. The behavior that the slider "jumps" to the middle of the bar when clicked and refuses to move further left is caused by wrongfully assigned minLimit & maxLimit slider options values. These values are not necessary (as we manually designate the value steps anyway). The removal of these assignments fixes the issue. We tested this change on several other timelines, both representing the normal case and the case of a long timedifference (as in 1.) with no issues.
This solves the main issue talked about in #462.