### PR TITLE
417/missing entities count

### DIFF
--- a/app/src/app/core/services/elasticsearch/data.service.ts
+++ b/app/src/app/core/services/elasticsearch/data.service.ts
@@ -162,8 +162,14 @@ export class DataService {
     return this.performQuery<T>(body);
   }
 
-  public async countEntityItems<T>(type: EntityType) {
-    const response: any = await this.http.get(this.countEndPoint + '?q=type:' + type).toPromise();
+  /**
+   * Get item count of type
+   * @param type the type which should be counted
+   */
+  public async countEntityItems<T>(type: EntityType){
+    const body = bodyBuilder()
+      .query('match', 'type', type);
+    const response: any = await this.http.post(this.countEndPoint, body.build()).toPromise();
     return response && response.count ? response.count : undefined;
   }
 

--- a/app/src/app/shared/components/timeline/timeline.component.ts
+++ b/app/src/app/shared/components/timeline/timeline.component.ts
@@ -126,7 +126,8 @@ export class TimelineComponent implements OnChanges {
       const endOfTimeline = this.items[this.items.length - 1].date -
         (this.items[this.items.length - 1].date % this.periodSpan) + this.periodSpan;
       // Set the slider of the timeline to the middle!
-      this.value = (beginOfTimeline + endOfTimeline) / 2;
+      // this.value = (beginOfTimeline + endOfTimeline) / 2;
+      this.value = this.items[Math.floor(this.items.length / 2)].date;
       this.previousValue = this.value;
       this.refreshComponent();
     }
@@ -209,8 +210,6 @@ export class TimelineComponent implements OnChanges {
     /** Set slider options */
     const newOptions: Options = Object.assign({}, this.options);
     newOptions.stepsArray = sliderSteps;
-    newOptions.minLimit = firstDate - firstPeriod;
-    newOptions.maxLimit = lastDate - firstPeriod;
     this.options = newOptions;
   }
 

--- a/app/src/app/shared/components/timeline/timeline.component.ts
+++ b/app/src/app/shared/components/timeline/timeline.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, HostListener} from '@angular/core';
+import {Component, Input, HostListener, OnChanges} from '@angular/core';
 import {Artist, Artwork, Entity, EntityType} from 'src/app/shared/models/models';
 import {CustomStepDefinition, Options} from '@angular-slider/ngx-slider';
 import {animate, state, style, transition, trigger} from '@angular/animations';
@@ -27,7 +27,7 @@ interface TimelineItem extends Entity {
     ])
   ]
 })
-export class TimelineComponent {
+export class TimelineComponent implements OnChanges {
   /** Artworks that should be displayed in this slider */
   @Input() artworks: Artwork[] = [];
   /** Decide whether artists should be displayed */
@@ -74,7 +74,7 @@ export class TimelineComponent {
     showTicks: true,
     showSelectionBar: false,
     stepsArray: [],
-    animateOnMove:true,
+    animateOnMove: true,
     getPointerColor() {
       return '#00bc8c';
     },
@@ -179,17 +179,28 @@ export class TimelineComponent {
       const distinctItems = this.items.filter(
         (thing, i, arr) => arr.findIndex(t => t.date === thing.date) === i
       );
+
+      /**
+       *  determine indices which divide distinctItems in averagePeriodCount blocks of roughly the same length
+       *  this method guarantees that the first and last element are always an index
+       */
+      const stepNr = (distinctItems.length - 1) / (this.averagePeriodCount - 1);
+      const indices = [];
+      for (let i = 0; i < this.averagePeriodCount; i++) {
+        indices.push(Math.floor(stepNr * i));
+      }
+
       sliderSteps = distinctItems.map((item, index) => {
         const step = {
           value: item.date,
           legend: ''
         };
-        if (index % Math.floor(distinctItems.length / this.averagePeriodCount) === 0) {
+
+        /** if current index is in indices make this item a legend point */
+        if (indices.includes(index)) {
           step.legend = item.date.toString();
         }
-        if (index === distinctItems.length - 1){
-          step.legend = item.date.toString();
-        }
+
         return step;
       });
     }

--- a/app/src/app/shared/components/timeline/timeline.component.ts
+++ b/app/src/app/shared/components/timeline/timeline.component.ts
@@ -176,12 +176,18 @@ export class TimelineComponent {
       }
     } else {
       /** if timeDifference bigger than maxSliderSteps, use the date values of the items */
-      sliderSteps = this.items.map((item, index) => {
+      const distinctItems = this.items.filter(
+        (thing, i, arr) => arr.findIndex(t => t.date === thing.date) === i
+      );
+      sliderSteps = distinctItems.map((item, index) => {
         const step = {
           value: item.date,
           legend: ''
         };
-        if (index % Math.floor(this.items.length / this.averagePeriodCount) === 0) {
+        if (index % Math.floor(distinctItems.length / this.averagePeriodCount) === 0) {
+          step.legend = item.date.toString();
+        }
+        if (index === distinctItems.length - 1){
           step.legend = item.date.toString();
         }
         return step;
@@ -205,7 +211,6 @@ export class TimelineComponent {
     const itemCountSmallerReference = 2;
     /** Amount of items where date is the exact slider value */
     const countReference = this.items.filter(item => +item.date === this.value).length;
-
     /** ReferenceIndex is the index of the first item with date equal to slider value or bigger */
     let referenceIndex: number;
     if (countReference > itemCountSmallerReference) {
@@ -214,7 +219,6 @@ export class TimelineComponent {
       const firstBiggerRef = this.items.findIndex(item => +item.date > this.value);
       referenceIndex = firstBiggerRef > 0 ? firstBiggerRef - 1 : this.items.length - (this.itemCountPerPeriod - 1);
     }
-
     /** Determine start index */
     if (0 >= referenceIndex - 1 && referenceIndex <= this.items.length - 3) {
       // first slide

--- a/app/src/app/shared/components/timeline/timeline.component.ts
+++ b/app/src/app/shared/components/timeline/timeline.component.ts
@@ -165,6 +165,9 @@ export class TimelineComponent implements OnChanges {
     const firstPeriod = firstDate - (firstDate % this.periodSpan);
     const lastPeriod = lastDate - (lastDate % this.periodSpan) + this.periodSpan;
 
+    /** setup options */
+    const newOptions: Options = Object.assign({}, this.options);
+
     /** Fill the slider steps with period legends respectively steps */
     const timeDifference = lastPeriod - firstPeriod;
     if (timeDifference <= this.maxSliderSteps) {
@@ -175,8 +178,16 @@ export class TimelineComponent implements OnChanges {
           sliderSteps.push({value: i});
         }
       }
+
+      /** set min and max slider limits */
+      newOptions.minLimit = firstDate - firstPeriod;
+      newOptions.maxLimit = lastDate - firstPeriod;
+
     } else {
-      /** if timeDifference bigger than maxSliderSteps, use the date values of the items */
+      /**
+       * if timeDifference bigger than maxSliderSteps, use distinct date values of the items
+       * This is done to avoid too much items in the timeline
+       */
       const distinctItems = this.items.filter(
         (thing, i, arr) => arr.findIndex(t => t.date === thing.date) === i
       );
@@ -206,9 +217,7 @@ export class TimelineComponent implements OnChanges {
       });
     }
 
-
     /** Set slider options */
-    const newOptions: Options = Object.assign({}, this.options);
     newOptions.stepsArray = sliderSteps;
     this.options = newOptions;
   }


### PR DESCRIPTION
The number of entities is missing in the staging and live versions of the OAB. This issue was not present if the application was run locally.

The query executed to count all items of a given EntityType was a manual elasticsearch  query. 
The query is now reqritten using bodybuilder. Locally this query works (as did the previous one). To test if this fixes the issue this fix has to be incorporated in the staging environment as the bug is only apparent there.

