### PR TITLE
#482 Added translations for search result page

### DIFF
--- a/app/src/app/pages/search-result/search-result.component.html
+++ b/app/src/app/pages/search-result/search-result.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row mb-5 border-bottom pb-5">
     <div class="col-sm-7">
-      <h2 class="mb-3 first-letter">Search result</h2>
+      <h2 class="mb-3 first-letter" i18n="Search results label@@searchResults">Search results</h2>
 
       <div class="row">
         <ng-container *ngFor="let result of searchResults; let i = index">
@@ -20,7 +20,7 @@
         </ng-container>
 
         <div class="col-md-3 pr-0" *ngIf="searchTerms?.length">
-          <p class="mb-1 text-muted">Terms:</p>
+          <p class="mb-1 text-muted colon-suffix" i18n="Terms label@@terms">Terms</p>
         </div>
 
         <div class="col-md-9 pl-0 info" *ngIf="searchTerms?.length">
@@ -30,7 +30,7 @@
         </div>
 
         <div class="col-md-3 pr-0">
-          <p class="mb-1 text-muted">Hits:</p>
+          <p class="mb-1 text-muted colon-suffix" i18n="Results label@@results">Results</p>
         </div>
 
         <div class="col-md-9 pl-0 info">
@@ -41,5 +41,5 @@
       </div>
     </div>
   </div>
-  <app-slider [items]="sliderItems" heading="Artworks"></app-slider>
+  <app-slider [items]="sliderItems" i18n-heading="Artworks label@@artworks" heading="Artworks"></app-slider>
 </div>

--- a/app/src/app/pages/search-result/search-result.component.scss
+++ b/app/src/app/pages/search-result/search-result.component.scss
@@ -1,0 +1,3 @@
+.colon-suffix:after {
+  content: ":";
+}

--- a/app/src/locale/messages.de.xlf
+++ b/app/src/locale/messages.de.xlf
@@ -876,6 +876,18 @@
         <source>Painting in progress</source>
         <target state="final">Hier wird noch gemalt</target>
       </trans-unit>
+      <trans-unit id="searchResults" datatype="html">
+        <source>Search results</source>
+        <target state="final">Suchergebnisse</target>
+      </trans-unit>
+      <trans-unit id="terms" datatype="html">
+        <source>Terms</source>
+        <target state="final">Begriffe</target>
+      </trans-unit>
+      <trans-unit id="results" datatype="html">
+        <source>Results</source>
+        <target state="final">Ergebnisse</target>
+      </trans-unit>
       <trans-unit id="d92b19d3d60f5e8db9974b16602fe83c00d05b7c" datatype="html">
         <source>{VAR_SELECT, select, all {All} artwork {Artwork} motif {Motif} artist {Artist} location {Location} genre
           {Genre} movement {Movement} material {Material} main_motif {Main Motif} }

--- a/app/src/locale/messages.de.xlf
+++ b/app/src/locale/messages.de.xlf
@@ -571,24 +571,6 @@
         </context-group>
         <note priority="1" from="description">Motif label</note>
       </trans-unit>
-      <trans-unit id="terms" datatype="html">
-        <source>Terms</source>
-        <target state="final">Begriffe</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/pages/search-result/search-result.component.html</context>
-          <context context-type="linenumber">102</context>
-        </context-group>
-        <note priority="1" from="description">Search Terms label</note>
-      </trans-unit>
-      <trans-unit id="hits" datatype="html">
-        <source>Hits</source>
-        <target state="final">Treffer</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/pages/search-result/search-result.component.html</context>
-          <context context-type="linenumber">114</context>
-        </context-group>
-        <note priority="1" from="description">Search Hits label</note>
-      </trans-unit>
       <trans-unit id="artworks" datatype="html">
         <source>Artworks</source>
         <target state="final">Kunstwerke</target>

--- a/app/src/locale/messages.en.xlf
+++ b/app/src/locale/messages.en.xlf
@@ -567,24 +567,6 @@
         </context-group>
         <note priority="1" from="description">Motif label</note>
       </trans-unit>
-      <trans-unit id="terms" datatype="html">
-        <source>Terms</source>
-        <target state="final">Terms</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/pages/search-result/search-result.component.html</context>
-          <context context-type="linenumber">102</context>
-        </context-group>
-        <note priority="1" from="description">Search Terms label</note>
-      </trans-unit>
-      <trans-unit id="hits" datatype="html">
-        <source>Hits</source>
-        <target state="final">Hits</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/pages/search-result/search-result.component.html</context>
-          <context context-type="linenumber">114</context>
-        </context-group>
-        <note priority="1" from="description">Search Hits label</note>
-      </trans-unit>
       <trans-unit id="artworks" datatype="html">
         <source>Artworks</source>
         <target state="final">Artworks</target>
@@ -871,6 +853,18 @@
       <trans-unit id="fetching_list_error" datatype="html">
         <source>Painting in progress</source>
         <target state="final">Painting in progress</target>
+      </trans-unit>
+      <trans-unit id="searchResults" datatype="html">
+        <source>Search results</source>
+        <target state="final">Search results</target>
+      </trans-unit>
+      <trans-unit id="terms" datatype="html">
+        <source>Terms</source>
+        <target state="final">Terms</target>
+      </trans-unit>
+      <trans-unit id="results" datatype="html">
+        <source>Results</source>
+        <target state="final">Results</target>
       </trans-unit>
       <trans-unit id="d92b19d3d60f5e8db9974b16602fe83c00d05b7c" datatype="html">
         <source>{VAR_SELECT, select, all {All} artwork {Artwork} motif {Motif} artist {Artist} location {Location} genre

--- a/app/src/locale/messages.es.xlf
+++ b/app/src/locale/messages.es.xlf
@@ -582,15 +582,6 @@
         </context-group>
         <note priority="1" from="description">Search Terms label</note>
       </trans-unit>
-      <trans-unit id="hits" datatype="html">
-        <source>Hits</source>
-        <target state="final">Respuestas positivas</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/pages/search-result/search-result.component.html</context>
-          <context context-type="linenumber">114</context>
-        </context-group>
-        <note priority="1" from="description">Search Hits label</note>
-      </trans-unit>
       <trans-unit id="artworks" datatype="html">
         <source>Artworks</source>
         <target state="final">Obras de arte</target>

--- a/app/src/locale/messages.es.xlf
+++ b/app/src/locale/messages.es.xlf
@@ -878,6 +878,18 @@
         <source>Painting in progress</source>
         <target state="final">Pintura en progreso</target>
       </trans-unit>
+      <trans-unit id="searchResults" datatype="html">
+        <source>Search results</source>
+        <target state="final">Resultados de búsqueda</target>
+      </trans-unit>
+      <trans-unit id="terms" datatype="html">
+        <source>Terms</source>
+        <target state="final">Términos</target>
+      </trans-unit>
+      <trans-unit id="results" datatype="html">
+        <source>Results</source>
+        <target state="final">Resultados</target>
+      </trans-unit>
       <trans-unit id="d92b19d3d60f5e8db9974b16602fe83c00d05b7c" datatype="html">
         <source>{VAR_SELECT, select, all {All} artwork {Artwork} motif {Motif} artist {Artist} location {Location} genre
           {Genre} movement {Movement} material {Material} main_motif {Main Motif} }

--- a/app/src/locale/messages.fr.xlf
+++ b/app/src/locale/messages.fr.xlf
@@ -898,6 +898,18 @@
         <source>Painting in progress</source>
         <target state="final">Peinture en cours</target>
       </trans-unit>
+      <trans-unit id="searchResults" datatype="html">
+        <source>Search results</source>
+        <target state="final">Résultats de la recherche</target>
+      </trans-unit>
+      <trans-unit id="terms" datatype="html">
+        <source>Terms</source>
+        <target state="final">Termes</target>
+      </trans-unit>
+      <trans-unit id="results" datatype="html">
+        <source>Results</source>
+        <target state="final">Résultats</target>
+      </trans-unit>
       <trans-unit id="d92b19d3d60f5e8db9974b16602fe83c00d05b7c" datatype="html">
         <source>{VAR_SELECT, select, all {All} artwork {Artwork} motif {Motif} artist {Artist} location {Location} genre
           {Genre} movement {Movement} material {Material} main_motif {Main Motif} }

--- a/app/src/locale/messages.fr.xlf
+++ b/app/src/locale/messages.fr.xlf
@@ -567,24 +567,6 @@
         </context-group>
         <note priority="1" from="description">Motif label</note>
       </trans-unit>
-      <trans-unit id="terms" datatype="html">
-        <source>Terms</source>
-        <target state="final">Termes</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/pages/search-result/search-result.component.html</context>
-          <context context-type="linenumber">102</context>
-        </context-group>
-        <note priority="1" from="description">Search Terms label</note>
-      </trans-unit>
-      <trans-unit id="hits" datatype="html">
-        <source>Hits</source>
-        <target state="final">Coups</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/pages/search-result/search-result.component.html</context>
-          <context context-type="linenumber">114</context>
-        </context-group>
-        <note priority="1" from="description">Search Hits label</note>
-      </trans-unit>
       <trans-unit id="artworks" datatype="html">
         <source>Artworks</source>
         <target state="final">Œuvres d'art</target>

--- a/app/src/locale/messages.it.xlf
+++ b/app/src/locale/messages.it.xlf
@@ -574,24 +574,6 @@
         </context-group>
         <note priority="1" from="description">Motif label</note>
       </trans-unit>
-      <trans-unit id="terms" datatype="html">
-        <source>Terms</source>
-        <target state="final">Termini</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/pages/search-result/search-result.component.html</context>
-          <context context-type="linenumber">102</context>
-        </context-group>
-        <note priority="1" from="description">Search Terms label</note>
-      </trans-unit>
-      <trans-unit id="hits" datatype="html">
-        <source>Hits</source>
-        <target state="final">Risposte pertinenti</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/pages/search-result/search-result.component.html</context>
-          <context context-type="linenumber">114</context>
-        </context-group>
-        <note priority="1" from="description">Search Hits label</note>
-      </trans-unit>
       <trans-unit id="artworks" datatype="html">
         <source>Artworks</source>
         <target state="final">Opere d'arte</target>

--- a/app/src/locale/messages.it.xlf
+++ b/app/src/locale/messages.it.xlf
@@ -878,6 +878,18 @@
         <source>Painting in progress</source>
         <target state="final">Verniciatura in corso</target>
       </trans-unit>
+      <trans-unit id="searchResults" datatype="html">
+        <source>Search results</source>
+        <target state="final">Risultati della ricerca</target>
+      </trans-unit>
+      <trans-unit id="terms" datatype="html">
+        <source>Terms</source>
+        <target state="final">Termini</target>
+      </trans-unit>
+      <trans-unit id="results" datatype="html">
+        <source>Results</source>
+        <target state="final">Risultati</target>
+      </trans-unit>
       <trans-unit id="d92b19d3d60f5e8db9974b16602fe83c00d05b7c" datatype="html">
         <source>{VAR_SELECT, select, all {All} artwork {Artwork} motif {Motif} artist {Artist} location {Location} genre
           {Genre} movement {Movement} material {Material} main_motif {Main Motif} }

--- a/app/src/locale/messages.xlf
+++ b/app/src/locale/messages.xlf
@@ -671,6 +671,10 @@
           <context context-type="sourcefile">app/pages/motif/motif.component.html</context>
           <context context-type="linenumber">21</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/components/movement-overview/movement-overview.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
         <note priority="1" from="description">Artworks label</note>
       </trans-unit>
       <trans-unit id="country" datatype="html">
@@ -704,6 +708,30 @@
           <context context-type="linenumber">22</context>
         </context-group>
         <note priority="1" from="description">error text for missing images</note>
+      </trans-unit>
+      <trans-unit id="searchResults" datatype="html">
+        <source>Search results</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/components/movement-overview/movement-overview.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Search results</note>
+      </trans-unit>
+      <trans-unit id="terms" datatype="html">
+        <source>Terms</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/components/movement-overview/movement-overview.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <note priority="1" from="description">Terms</note>
+      </trans-unit>
+      <trans-unit id="results" datatype="html">
+        <source>Results</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/components/movement-overview/movement-overview.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Results</note>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
This branch fixes the issue #482.

To fix this issue the text passages had to be annotated for translation.
Additionally they were added to the messages.xlf and the individual translation files (i.e. messages.de.xlf).
There the phrases had to be manually translated.