### PR TITLE
476/movement timeline alignment

### DIFF
--- a/app/src/app/pages/movement/movement.component.html
+++ b/app/src/app/pages/movement/movement.component.html
@@ -70,7 +70,7 @@
       </div>
       <div class="tab-pane fade" [ngClass]="{ 'show active': activeTab === Tab.MovementOverview }" id="movement_overview_tab">
         <app-movement-overview
-          *ngIf="(activeTab === Tab.MovementOverview || movementOverviewLoaded) && movement && relatedMovements.length > 0"
+          *ngIf="(activeTab === Tab.MovementOverview) && movement && relatedMovements.length > 0"
           [inputMovements]="relatedMovements"></app-movement-overview>
       </div>
     </div>

--- a/app/src/app/shared/components/movement-overview/movement-overview.component.ts
+++ b/app/src/app/shared/components/movement-overview/movement-overview.component.ts
@@ -310,6 +310,7 @@ export class MovementOverviewComponent implements OnInit, AfterViewInit, OnDestr
   }
 
   onThumbnailLoaded() {
+    this.showThumbnail = true;
     this.thumbnailLoaded = true;
   }
 
@@ -352,6 +353,7 @@ export class MovementOverviewComponent implements OnInit, AfterViewInit, OnDestr
   }
 
   selectRandomMovement() {
+    console.log("TEST")
     let randIndex = Math.floor(Math.random() * this.movements.length);
     if (this.movements[randIndex].id === this.currentMovementId) {
       randIndex = (randIndex + 1) % this.movements.length;

--- a/app/src/app/shared/components/movement-overview/movement-overview.component.ts
+++ b/app/src/app/shared/components/movement-overview/movement-overview.component.ts
@@ -353,7 +353,6 @@ export class MovementOverviewComponent implements OnInit, AfterViewInit, OnDestr
   }
 
   selectRandomMovement() {
-    console.log("TEST")
     let randIndex = Math.floor(Math.random() * this.movements.length);
     if (this.movements[randIndex].id === this.currentMovementId) {
       randIndex = (randIndex + 1) % this.movements.length;


### PR DESCRIPTION
This branch fixes the issue #476.

The cause for this issue was that the related movements tab was rendered even though it is initially hidden (and therefore has no width), which resulted in the wrong initial alignment of the thumbnails for related movements.