### PR TITLE
Removed header for results label.

### DIFF
--- a/app/src/app/pages/search-result/search-result.component.html
+++ b/app/src/app/pages/search-result/search-result.component.html
@@ -41,5 +41,5 @@
       </div>
     </div>
   </div>
-  <app-slider [items]='sliderItems' heading="Results label@@results"></app-slider>
+  <app-slider [items]='sliderItems'></app-slider>
 </div>


### PR DESCRIPTION
Removed header (one line code change). Result in local test as follows:

![image](https://user-images.githubusercontent.com/6040299/122680123-10d8d700-d1ee-11eb-9b4e-5944ec36ad42.png)

After quick review, hotfix will be merged.