### PR TITLE
#527 Implements retries while fetching the wikipedia extracts. 

### DIFF
--- a/etl/data_extraction/get_wikipedia_extracts.py
+++ b/etl/data_extraction/get_wikipedia_extracts.py
@@ -253,6 +253,10 @@ def add_wikipedia_extracts(language_keys: Optional[List[str]] = lang_keys, ) -> 
                                     flush=True,
                                 )
 
+                                # If a chunk is finished and the chunk size is < 20 (e.g. the previous chunk failed but the current one succeeded): increase the chunk size
+                                chunk_size = chunk_size + 5 if chunk_size < 20 else chunk_size
+
+
                             # set done to true after all items have been processed
                             done = True
                         except Exception as error:

--- a/etl/data_extraction/request_utils.py
+++ b/etl/data_extraction/request_utils.py
@@ -55,9 +55,9 @@ def send_http_request(
             response = response.json()
             if abstracts and "batchcomplete" not in response:
                 logging.error(
-                    "Looks like not all extracts were loaded from wikipedia. Decrease the groupsize to avoid this behavior. Exiting script now"
+                    "Looks like not all extracts were loaded from wikipedia. Decrease the groupsize to avoid this behavior. Raising RuntimeError"
                 )
-                exit(-1)
+                raise RuntimeError
             if "error" in response:
                 # ToDo: more specific error handling since unknown ids error throws a different message
                 print(
@@ -91,6 +91,8 @@ def send_http_request(
                 return ""
             else:
                 continue
+        except RuntimeError as runtimeError:
+            raise runtimeError
         except Exception as error:
             print(
                 f"Unknown error. Time: {datetime.datetime.now()}. Error: {error}. Following items couldn't be loaded: {items}"


### PR DESCRIPTION
#527 Each time a language and type extract fails the script tries again with a smaller batch size. This also changes request_utils.py as this script handled the error caused by the chunk size being too large by calling exit(-1), completely stopping the crawl which is less than ideal.

This has been tested in branch 524 and is working as intended.