### PR TITLE
#564 Matomo Changes

### DIFF
--- a/app/src/app/pages/data-protection/data-protection.component.html
+++ b/app/src/app/pages/data-protection/data-protection.component.html
@@ -224,7 +224,7 @@
   <ul>
     <li>
       <p>
-        Anonymisierte IP-Adressen indem die letzten 2 bytes entfernt werden (also 198.51.0.0 anstatt 198.51.100.54)
+        Anonymisierte IP-Adressen indem die letzten 2 bytes entfernt werden (also 198.51.xxx.xxx anstatt 198.51.100.54)
       </p>
     </li>
     <li>
@@ -259,10 +259,12 @@
     </li>
   </ul>
 
+  <!-- The opt-out box should be removed. If it is needed, remove these comments.
   <iframe
     style="border: 0; height: 200px; width: 100%;"
     src="https://openartbrowser.org/api/analytics/index.php?module=CoreAdminHome&action=optOut&language=de&backgroundColor=&fontColor=fff&fontSize=&fontFamily="
   ></iframe>
+  -->
 
   <p>
     Quelle:


### PR DESCRIPTION
#564 

IP Addresse angepasst: 198.51.xxx.xxx

Opt-out versteckt hinter Kommentare. Kann wieder eingeblendet werden bei Bedarf.

Ergebnis getestet:

![image](https://user-images.githubusercontent.com/6040299/124134940-a7758580-da83-11eb-9d27-dfcdfae1b346.png)
