### PR TITLE
#557: Fixed mobile paginator bug

### DIFF
--- a/app/src/app/shared/components/fetching-list/fetching-list.component.scss
+++ b/app/src/app/shared/components/fetching-list/fetching-list.component.scss
@@ -189,7 +189,7 @@
   }
 
   .fetching-list-paginator .paginator {
-    top: 150px;
+    top: 175px;
     pointer-events: all;
   }
 }

--- a/app/src/styles/styles.scss
+++ b/app/src/styles/styles.scss
@@ -4,7 +4,8 @@
 
 html,
 body {
-  height: 100%;
+  height: auto;
+  min-height: 100%;
   scrollbar-color: #888 transparent; //custom colors only for firefox
 }
 


### PR DESCRIPTION
Fixes #557

The cause of the issue was the `height: 100%` on the `body` element, which caused the window to have a fixed height (screen height) and therefore to not be scrollable.